### PR TITLE
Fixed number of epochs in minibatch training to 1

### DIFF
--- a/models/client.py
+++ b/models/client.py
@@ -15,7 +15,7 @@ class Client:
         """Trains on self.model using the client's train_data.
 
         Args:
-            num_epochs: Number of epochs to train.
+            num_epochs: Number of epochs to train. Unsupported if minibatch is provided (minibatch has only 1 epoch)
             batch_size: Size of training batches.
             minibatch: fraction of client's data to apply minibatch sgd,
                 None to use FedAvg
@@ -33,6 +33,9 @@ class Client:
             num_data = max(1, int(frac*len(self.train_data["x"])))
             xs, ys = zip(*random.sample(list(zip(self.train_data["x"], self.train_data["y"])), num_data))
             data = {"x": xs, "y": ys}
+
+            # Minibatch trains for only 1 epoch - multiple local epochs don't make sense!
+            num_epochs = 1
             comp, update = self.model.train(data, num_epochs, num_data)
         num_train_samples = len(data)
         return comp, num_train_samples, update

--- a/models/main.py
+++ b/models/main.py
@@ -127,14 +127,18 @@ def parse_args():
                     help='batch size when clients train on data;',
                     type=int,
                     default=10)
-    parser.add_argument('--minibatch',
+
+    # Minibatch doesn't support num_epochs, so make them mutually exclusive
+    epoch_capability_group = parser.add_mutually_exclusive_group()
+    epoch_capability_group.add_argument('--minibatch',
                     help='None for FedAvg, else fraction;',
                     type=float,
                     default=None)
-    parser.add_argument('--num_epochs',
+    epoch_capability_group.add_argument('--num_epochs',
                     help='number of epochs when clients train on data;',
                     type=int,
                     default=1)
+
     parser.add_argument('-t',
                     help='simulation time: small, medium, or large;',
                     type=str,


### PR DESCRIPTION
As per discussions with @scaldas, multiple epochs with minibatch training don't make sense. This PR fixes the number of epochs to 1 when using minibatch, and makes the `--minibatch` CLI option incompatible with `--num_epochs` (to avoid unexpected behaviour)