### PR TITLE
Added support for seed specification, digest generation and verification

### DIFF
--- a/data/femnist/README.md
+++ b/data/femnist/README.md
@@ -10,6 +10,8 @@
     - ```-k``` := minimum number of samples per user
     - ```-t``` := 'user' to partition users into train-test groups, or 'sample' to partition each user's samples into train-test groups
     - ```--tf``` := fraction of data in training set, written as a decimal; default is 0.9
+    - ```--smplseed``` := seed to be used before random sampling of data
+    - ```--spltseed``` :=  seed to be used before random split of data
 
 i.e.
 - ```./preprocess.sh -s niid --sf 1.0 -k 0 -t sample``` (full-sized dataset)<br/>

--- a/data/sent140/README.md
+++ b/data/sent140/README.md
@@ -10,6 +10,8 @@ Run preprocess.sh with a choice of the following tags:
 - ```-k``` := minimum number of samples per user
 - ```-t``` := 'user' to partition users into train-test groups, or 'sample' to partition each user's samples into train-test groups
 - ```--tf``` := fraction of data in training set, written as a decimal; default is 0.9
+- ```--smplseed``` := seed to be used before random sampling of data
+- ```--spltseed``` :=  seed to be used before random split of data
 
 i.e. 
 - ```./preprocess.sh -s niid --sf 1.0 -k 0 -t sample``` (full-sized dataset)<br/>

--- a/data/shakespeare/README.md
+++ b/data/shakespeare/README.md
@@ -10,6 +10,8 @@
   - ```-t``` := 'user' to partition users into train-test groups, or 'sample' to partition each user's samples into train-test groups; default is 'sample'
   - ```--tf``` := fraction of data in training set, written as a decimal; default is 0.9
   - ```--raw``` := include users' raw text data in all_data.json
+  - ```--smplseed``` := seed to be used before random sampling of data
+  - ```--spltseed``` :=  seed to be used before random split of data
 
 i.e.
 - ```./preprocess.sh -s niid --sf 1.0 -k 0 -t sample -tf 0.8``` (full-sized dataset)<br/>

--- a/data/utils/constants.py
+++ b/data/utils/constants.py
@@ -1,1 +1,2 @@
 DATASETS = ['sent140', 'femnist', 'shakespeare']
+SEED_FILES = { 'sampling': 'sampling_seed.txt', 'split': 'split_seed.txt' }

--- a/data/utils/preprocess.sh
+++ b/data/utils/preprocess.sh
@@ -172,15 +172,13 @@ if [ "$CONT_SCRIPT" = true ] && [ ! $SAMPLE = "na" ]; then
 
         cd ../utils
 
-        SEED_ARGUMENT=""
-        if [ -n "${SAMPLING_SEED}" ]; then
-            SEED_ARGUMENT="--seed ${SAMPLING_SEED}"
-        fi
+        # Defaults to -1 if not specified, causes script to randomly generate seed
+        SEED_ARGUMENT="${SAMPLING_SEED:--1}" 
 
         if [ $SAMPLE = "iid" ]; then
-            LEAF_DATA_META_DIR=${META_DIR} python3 sample.py $NAMETAG --iid $IUSERTAG $SFRACTAG ${SEED_ARGUMENT}
+            LEAF_DATA_META_DIR=${META_DIR} python3 sample.py $NAMETAG --iid $IUSERTAG $SFRACTAG --seed ${SEED_ARGUMENT}
         else
-            LEAF_DATA_META_DIR=${META_DIR} python3 sample.py $NAMETAG $SFRACTAG ${SEED_ARGUMENT}
+            LEAF_DATA_META_DIR=${META_DIR} python3 sample.py $NAMETAG $SFRACTAG --seed ${SEED_ARGUMENT}
         fi
 
         cd ../$NAME
@@ -227,17 +225,15 @@ if [ "$CONT_SCRIPT" = true ] && [ ! $TRAIN = "na" ]; then
 
         cd ../utils
 
-        SEED_ARGUMENT=""
-        if [ -n "${SPLIT_SEED}" ]; then
-            SEED_ARGUMENT="--seed ${SPLIT_SEED}"
-        fi
+        # Defaults to -1 if not specified, causes script to randomly generate seed
+        SEED_ARGUMENT="${SPLIT_SEED:--1}"
 
         if [ -z $TRAIN ]; then
-            LEAF_DATA_META_DIR=${META_DIR} python3 split_data.py $NAMETAG $TFRACTAG ${SEED_ARGUMENT}
+            LEAF_DATA_META_DIR=${META_DIR} python3 split_data.py $NAMETAG $TFRACTAG --seed ${SEED_ARGUMENT}
         elif [ $TRAIN = "user" ]; then
-            LEAF_DATA_META_DIR=${META_DIR} python3 split_data.py $NAMETAG --by_user $TFRACTAG ${SEED_ARGUMENT}
+            LEAF_DATA_META_DIR=${META_DIR} python3 split_data.py $NAMETAG --by_user $TFRACTAG --seed ${SEED_ARGUMENT}
         elif [ $TRAIN = "sample" ]; then
-            LEAF_DATA_META_DIR=${META_DIR} python3 split_data.py $NAMETAG --by_sample $TFRACTAG ${SEED_ARGUMENT}
+            LEAF_DATA_META_DIR=${META_DIR} python3 split_data.py $NAMETAG --by_sample $TFRACTAG --seed ${SEED_ARGUMENT}
         fi
 
         cd ../$NAME

--- a/data/utils/preprocess.sh
+++ b/data/utils/preprocess.sh
@@ -22,93 +22,93 @@ CHECKSUM_FNAME="${META_DIR}/dir-checksum.md5"
 
 while [[ $# -gt 0 ]]
 do
-    key="$1"
+key="$1"
 
-    # TODO: Use getopts instead of creating cases!
-    case $key in
-        --name)
-        NAME="$2"
-        shift # past argument
-        if [ ${SAMPLE:0:1} = "-" ]; then
-            NAME="sent140"
-        else
-            shift # past value
-        fi
-        ;;
-        -s)
-        SAMPLE="$2"
-        shift # past argument
-        if [ ${SAMPLE:0:1} = "-" ]; then
-            SAMPLE=""
-        else
-            shift # past value
-        fi
-        ;;
-        --iu)
-        IUSER="$2"
-        shift # past argument
-        if [ ${IUSER:0:1} = "-" ]; then
-            IUSER=""
-        else
-            shift # past value
-        fi
-        ;;
-        --sf)
-        SFRAC="$2"
-        shift # past argument
-        if [ ${SFRAC:0:1} = "-" ]; then
-            SFRAC=""
-        else
-            shift # past value
-        fi
-        ;;
-        -k)
-        MINSAMPLES="$2"
-        shift # past argument
-        if [ ${MINSAMPLES:0:1} = "-" ]; then
-            MINSAMPLES=""
-        else
-            shift # past value
-        fi
-        ;;
-        -t)
-        TRAIN="$2"
-        shift # past argument
-        if [ -z "$TRAIN" ] || [ ${TRAIN:0:1} = "-" ]; then
-            TRAIN=""
-        else
-            shift # past value
-        fi
-        ;;
-        --tf)
-        TFRAC="$2"
-        shift # past argument
-        if [ ${TFRAC:0:1} = "-" ]; then
-            TFRAC=""
-        else
-            shift # past value
-        fi
-        ;;
-        --smplseed)
-        SAMPLING_SEED="$2"
-        shift # past argument
-        ;;
-        --spltseed)
-        SPLIT_SEED="$2"
-        shift # past argument
-        ;;
-        --nochecksum)
-        NO_CHECKSUM="true"
-        shift # past argument
-        ;;
-        --verify)
-        VERIFICATION_FILE="$2"
-        shift # past argument
-        ;;
-        *)    # unknown option
-        shift # past argument
-        ;;
-    esac
+# TODO: Use getopts instead of creating cases!
+case $key in
+    --name)
+    NAME="$2"
+    shift # past argument
+    if [ ${SAMPLE:0:1} = "-" ]; then
+        NAME="sent140"
+    else
+        shift # past value
+    fi
+    ;;
+    -s)
+    SAMPLE="$2"
+    shift # past argument
+    if [ ${SAMPLE:0:1} = "-" ]; then
+        SAMPLE=""
+    else
+        shift # past value
+    fi
+    ;;
+    --iu)
+    IUSER="$2"
+    shift # past argument
+    if [ ${IUSER:0:1} = "-" ]; then
+        IUSER=""
+    else
+        shift # past value
+    fi
+    ;;
+    --sf)
+    SFRAC="$2"
+    shift # past argument
+    if [ ${SFRAC:0:1} = "-" ]; then
+        SFRAC=""
+    else
+        shift # past value
+    fi
+    ;;
+    -k)
+    MINSAMPLES="$2"
+    shift # past argument
+    if [ ${MINSAMPLES:0:1} = "-" ]; then
+        MINSAMPLES=""
+    else
+        shift # past value
+    fi
+    ;;
+    -t)
+    TRAIN="$2"
+    shift # past argument
+    if [ -z "$TRAIN" ] || [ ${TRAIN:0:1} = "-" ]; then
+        TRAIN=""
+    else
+        shift # past value
+    fi
+    ;;
+    --tf)
+    TFRAC="$2"
+    shift # past argument
+    if [ ${TFRAC:0:1} = "-" ]; then
+        TFRAC=""
+    else
+        shift # past value
+    fi
+    ;;
+    --smplseed)
+    SAMPLING_SEED="$2"
+    shift # past argument
+    ;;
+    --spltseed)
+    SPLIT_SEED="$2"
+    shift # past argument
+    ;;
+    --nochecksum)
+    NO_CHECKSUM="true"
+    shift # past argument
+    ;;
+    --verify)
+    VERIFICATION_FILE="$2"
+    shift # past argument
+    ;;
+    *)    # unknown option
+    shift # past argument
+    ;;
+esac
 done
 
 # --------------------

--- a/data/utils/preprocess.sh
+++ b/data/utils/preprocess.sh
@@ -12,86 +12,135 @@ SFRAC="" # --sf tag, fraction of data to sample
 MINSAMPLES="na" # -k tag, minimum allowable # of samples per user
 TRAIN="na" # -t tag, user or sample
 TFRAC="" # --tf tag, fraction of data in training set
+SAMPLING_SEED="" # --smplseed, seed specified for sampling of data
+SPLIT_SEED="" # --spltseed, seed specified for train/test data split
+NO_CHECKSUM="" # --nochecksum, disable creation of MD5 checksum file after data gen
+VERIFICATION_FILE="" # --verify <fname>, check if JSON files' MD5 matches given digest
+
+META_DIR='meta'
+CHECKSUM_FNAME="${META_DIR}/dir-checksum.md5"
 
 while [[ $# -gt 0 ]]
 do
-key="$1"
+    key="$1"
 
-case $key in
-    --name)
-    NAME="$2"
-    shift # past argument
-    if [ ${SAMPLE:0:1} = "-" ]; then
-        NAME="sent140"
-    else
-        shift # past value
-    fi
-    ;;
-    -s)
-    SAMPLE="$2"
-    shift # past argument
-    if [ ${SAMPLE:0:1} = "-" ]; then
-        SAMPLE=""
-    else
-        shift # past value
-    fi
-    ;;
-    --iu)
-    IUSER="$2"
-    shift # past argument
-    if [ ${IUSER:0:1} = "-" ]; then
-        IUSER=""
-    else
-        shift # past value
-    fi
-    ;;
-    --sf)
-    SFRAC="$2"
-    shift # past argument
-    if [ ${SFRAC:0:1} = "-" ]; then
-        SFRAC=""
-    else
-        shift # past value
-    fi
-    ;;
-    -k)
-    MINSAMPLES="$2"
-    shift # past argument
-    if [ ${MINSAMPLES:0:1} = "-" ]; then
-        MINSAMPLES=""
-    else
-        shift # past value
-    fi
-    ;;
-    -t)
-    TRAIN="$2"
-    shift # past argument
-    if [ -z "$TRAIN" ] || [ ${TRAIN:0:1} = "-" ]; then
-        TRAIN=""
-    else
-        shift # past value
-    fi
-    ;;
-    --tf)
-    TFRAC="$2"
-    shift # past argument
-    if [ ${TFRAC:0:1} = "-" ]; then
-        TFRAC=""
-    else
-        shift # past value
-    fi
-    ;;
-    *)    # unknown option
-    shift # past argument
-    ;;
-esac
+    # TODO: Use getopts instead of creating cases!
+    case $key in
+        --name)
+        NAME="$2"
+        shift # past argument
+        if [ ${SAMPLE:0:1} = "-" ]; then
+            NAME="sent140"
+        else
+            shift # past value
+        fi
+        ;;
+        -s)
+        SAMPLE="$2"
+        shift # past argument
+        if [ ${SAMPLE:0:1} = "-" ]; then
+            SAMPLE=""
+        else
+            shift # past value
+        fi
+        ;;
+        --iu)
+        IUSER="$2"
+        shift # past argument
+        if [ ${IUSER:0:1} = "-" ]; then
+            IUSER=""
+        else
+            shift # past value
+        fi
+        ;;
+        --sf)
+        SFRAC="$2"
+        shift # past argument
+        if [ ${SFRAC:0:1} = "-" ]; then
+            SFRAC=""
+        else
+            shift # past value
+        fi
+        ;;
+        -k)
+        MINSAMPLES="$2"
+        shift # past argument
+        if [ ${MINSAMPLES:0:1} = "-" ]; then
+            MINSAMPLES=""
+        else
+            shift # past value
+        fi
+        ;;
+        -t)
+        TRAIN="$2"
+        shift # past argument
+        if [ -z "$TRAIN" ] || [ ${TRAIN:0:1} = "-" ]; then
+            TRAIN=""
+        else
+            shift # past value
+        fi
+        ;;
+        --tf)
+        TFRAC="$2"
+        shift # past argument
+        if [ ${TFRAC:0:1} = "-" ]; then
+            TFRAC=""
+        else
+            shift # past value
+        fi
+        ;;
+        --smplseed)
+        SAMPLING_SEED="$2"
+        shift # past argument
+        ;;
+        --spltseed)
+        SPLIT_SEED="$2"
+        shift # past argument
+        ;;
+        --nochecksum)
+        NO_CHECKSUM="true"
+        shift # past argument
+        ;;
+        --verify)
+        VERIFICATION_FILE="$2"
+        shift # past argument
+        ;;
+        *)    # unknown option
+        shift # past argument
+        ;;
+    esac
 done
+
+# --------------------
+# check if running in verification mode
+
+if [ -n "${VERIFICATION_FILE}" ]; then
+    pushd ../$NAME >/dev/null 2>/dev/null
+        TMP_FILE=`mktemp /tmp/dir-checksum.XXXXXXX`
+        find 'data/' -type f -name '*.json' -exec md5sum {} + | sort -k 2 > ${TMP_FILE}
+        DIFF=`diff --brief ${VERIFICATION_FILE} ${TMP_FILE}`
+        if [ $? -ne 0 ]; then
+            echo "${DIFF}"
+            diff ${TMP_FILE} ${VERIFICATION_FILE} 
+            echo "Differing checksums found - please verify"
+        else
+            echo "Matching JSON files and checksums found!"
+        fi
+    popd >/dev/null 2>/dev/null
+    exit 0
+fi
 
 # --------------------
 # preprocess data
 
 CONT_SCRIPT=true
 cd ../$NAME
+
+# setup meta directory if doesn't exist
+if [ ! -d ${META_DIR} ]; then
+    mkdir -p ${META_DIR}
+fi
+META_DIR=`realpath ${META_DIR}`
 
 # download data and convert to .json format
 
@@ -123,10 +172,15 @@ if [ "$CONT_SCRIPT" = true ] && [ ! $SAMPLE = "na" ]; then
 
         cd ../utils
 
+        SEED_ARGUMENT=""
+        if [ -n "${SAMPLING_SEED}" ]; then
+            SEED_ARGUMENT="--seed ${SAMPLING_SEED}"
+        fi
+
         if [ $SAMPLE = "iid" ]; then
-            python3 sample.py $NAMETAG --iid $IUSERTAG $SFRACTAG
+            LEAF_DATA_META_DIR=${META_DIR} python3 sample.py $NAMETAG --iid $IUSERTAG $SFRACTAG ${SEED_ARGUMENT}
         else
-            python3 sample.py $NAMETAG $SFRACTAG
+            LEAF_DATA_META_DIR=${META_DIR} python3 sample.py $NAMETAG $SFRACTAG ${SEED_ARGUMENT}
         fi
 
         cd ../$NAME
@@ -173,16 +227,28 @@ if [ "$CONT_SCRIPT" = true ] && [ ! $TRAIN = "na" ]; then
 
         cd ../utils
 
+        SEED_ARGUMENT=""
+        if [ -n "${SPLIT_SEED}" ]; then
+            SEED_ARGUMENT="--seed ${SPLIT_SEED}"
+        fi
+
         if [ -z $TRAIN ]; then
-            python3 split_data.py $NAMETAG $TFRACTAG
+            LEAF_DATA_META_DIR=${META_DIR} python3 split_data.py $NAMETAG $TFRACTAG ${SEED_ARGUMENT}
         elif [ $TRAIN = "user" ]; then
-            python3 split_data.py $NAMETAG --by_user $TFRACTAG
+            LEAF_DATA_META_DIR=${META_DIR} python3 split_data.py $NAMETAG --by_user $TFRACTAG ${SEED_ARGUMENT}
         elif [ $TRAIN = "sample" ]; then
-            python3 split_data.py $NAMETAG --by_sample $TFRACTAG
+            LEAF_DATA_META_DIR=${META_DIR} python3 split_data.py $NAMETAG --by_sample $TFRACTAG ${SEED_ARGUMENT}
         fi
 
         cd ../$NAME
     fi
+fi
+
+if [ -z "${NO_CHECKSUM}" ]; then
+    echo '------------------------------'
+    echo "calculating JSON file checksums"
+    find 'data/' -type f -name '*.json' -exec md5sum {} + | sort -k 2 > ${CHECKSUM_FNAME}
+    echo "checksums written to ${CHECKSUM_FNAME}"
 fi
 
 if [ "$CONT_SCRIPT" = false ]; then

--- a/data/utils/sample.py
+++ b/data/utils/sample.py
@@ -57,7 +57,7 @@ subdir = os.path.join(data_dir, 'all_data')
 files = os.listdir(subdir)
 files = [f for f in files if f.endswith('.json')]
 
-rng_seed = (args.seed if args.seed is not None else int(time.time()))
+rng_seed = (args.seed if (args.seed is not None and args.seed >= 0) else int(time.time()))
 print ("Using seed {}".format(rng_seed))
 rng = random.Random(rng_seed)
 print (os.environ.get('LEAF_DATA_META_DIR'))

--- a/data/utils/sample.py
+++ b/data/utils/sample.py
@@ -57,7 +57,8 @@ subdir = os.path.join(data_dir, 'all_data')
 files = os.listdir(subdir)
 files = [f for f in files if f.endswith('.json')]
 
-rng_seed = (seed if args.seed is not None else int(time.time())
+rng_seed = (args.seed if args.seed is not None else int(time.time()))
+print ("Using seed {}".format(rng_seed))
 rng = random.Random(rng_seed)
 print (os.environ.get('LEAF_DATA_META_DIR'))
 if os.environ.get('LEAF_DATA_META_DIR') is not None:

--- a/data/utils/split_data.py
+++ b/data/utils/split_data.py
@@ -117,7 +117,7 @@ if len(files) == 0:
     files = os.listdir(subdir)
 files = [f for f in files if f.endswith('.json')]
 
-rng_seed = (args.seed if args.seed is not None else int(time.time()))
+rng_seed = (args.seed if (args.seed is not None and args.seed >= 0) else int(time.time()))
 rng = random.Random(rng_seed)
 if os.environ.get('LEAF_DATA_META_DIR') is not None:
     seed_fname = os.path.join(os.environ.get('LEAF_DATA_META_DIR'), SEED_FILES['split'])

--- a/models/main.py
+++ b/models/main.py
@@ -5,6 +5,7 @@ import importlib
 import numpy as np
 import os
 import sys
+import random
 import tensorflow as tf
 
 import metrics.writer as metrics_writer
@@ -24,6 +25,10 @@ SYS_METRICS_PATH = 'metrics/sys_metrics.csv'
 def main():
 
     args = parse_args()
+
+    # Set the random seed if provided (affects client sampling, and batching)
+    if args.seed is not None:
+        random.seed(args.seed)
 
     model_path = '%s/%s.py' % (args.dataset, args.model)
     if not os.path.exists(model_path):
@@ -127,6 +132,10 @@ def parse_args():
                     help='batch size when clients train on data;',
                     type=int,
                     default=10)
+    parser.add_argument('--seed',
+                    help='seed for random client sampling and batch splitting',
+                    type=int,
+                    default=None)
 
     # Minibatch doesn't support num_epochs, so make them mutually exclusive
     epoch_capability_group = parser.add_mutually_exclusive_group()


### PR DESCRIPTION
`preprocess.sh` changes:
- added `--spltseed` flag for providing seed to RNG used for train/test split
- added `--smplseed` flag for providing seed to RNG used for subsampling fraction of data
- added default generation of MD5 digest for JSON files in dataset directory (also added `--nochecksum` flag to disable default behaviour)
- added `--verify <fname>` flag for comparing MD5 digest of JSON files in `data/` directory against provided file
- added support for saving seeds used for sampling and splitting in a `meta/` directory

Changes to other files in `data/utils/` are mostly for supporting these additions