### PR TITLE
Fix: FEMNIST dataset not complete.

### DIFF
--- a/data/femnist/preprocess/data_to_json.py
+++ b/data/femnist/preprocess/data_to_json.py
@@ -73,7 +73,7 @@ for (w, l) in writers:
         user_data[w]['y'].append(nc)
 
     writer_count += 1
-    if writer_count == MAX_WRITERS:
+    if writer_count == MAX_WRITERS or writer_count == len(writers):
 
         all_data = {}
         all_data['users'] = users


### PR DESCRIPTION
The data_to_json.py script only generated 3500 of the 3597 existing users.

This PR fixes that.

I'm still curious why the LEAF homepage lists 3,550 instead of 3597 users for FEMNIST?