### PR TITLE
fix a bug in models/client.py

### DIFF
--- a/models/client.py
+++ b/models/client.py
@@ -32,7 +32,7 @@ class Client:
             frac = min(1.0, minibatch)
             num_data = max(1, int(frac*len(self.train_data["x"])))
             xs, ys = zip(*random.sample(list(zip(self.train_data["x"], self.train_data["y"])), num_data))
-            data = {'x': xs, 'y': ys}
+            data = {'x': list(xs), 'y': list(ys)}
 
             # Minibatch trains for only 1 epoch - multiple local epochs don't make sense!
             num_epochs = 1


### PR DESCRIPTION
When I run './femnist.sh' in the directory 'leaf/paper_experiment', an error occurs that is: 
![image](https://user-images.githubusercontent.com/38368472/110194159-0595b180-7e72-11eb-8f24-01ceede1f43e.png)
Converting the type of **xs** and **ys** to **list**  really fixes this bug.
