### PR TITLE
Update get_data.sh, Sent140 Data URL HTTP not working

### DIFF
--- a/data/sent140/preprocess/get_data.sh
+++ b/data/sent140/preprocess/get_data.sh
@@ -3,7 +3,7 @@
 cd ../data/raw_data
 
 if [ ! -f trainingandtestdata.zip ]; then
-    wget --no-check-certificate http://cs.stanford.edu/people/alecmgo/trainingandtestdata.zip
+    wget --no-check-certificate https://cs.stanford.edu/people/alecmgo/trainingandtestdata.zip
 fi
 
 unzip trainingandtestdata.zip


### PR DESCRIPTION
### Pull Request: Update Sent140 Data URL from HTTP to HTTPS

#### Summary:
This update modifies the URL used to download the Sent140 dataset, changing the protocol from `http` to `https` as the old url isn't working.

#### Changes:
- Updated the Sent140 data download URL to use `https` instead of `http`.

#### Reason for Change:
Switching from HTTP to HTTPS since the old URL isn't working.
