### PR TITLE
Update get_data.sh, URL not working for Shakespeare dataset.

### DIFF
--- a/data/shakespeare/preprocess/get_data.sh
+++ b/data/shakespeare/preprocess/get_data.sh
@@ -2,7 +2,7 @@
 
 cd ../data/raw_data
 
-wget http://www.gutenberg.org/files/100/old/1994-01-100.zip
+wget http://www.gutenberg.org/files/100/old/old/1994-01-100.zip
 unzip 1994-01-100.zip
 rm 1994-01-100.zip
 mv 100.txt raw_data.txt


### PR DESCRIPTION
This pull request includes a small change to the `data/shakespeare/preprocess/get_data.sh` file. The change updates the URL for downloading the Shakespeare dataset.
Updated the URL from `http://www.gutenberg.org/files/100/old/1994-01-100.zip` to `http://www.gutenberg.org/files/100/old/old/1994-01-100.zip`.